### PR TITLE
Move socket creation for Firefox compatibility

### DIFF
--- a/jeopardy.html
+++ b/jeopardy.html
@@ -186,7 +186,6 @@ body.finalJeopardy {
 <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.4.0"></script>
 <script>
 let server = window.prompt("What server are you trying to connect to?");
-let socket = new WebSocket("wss://" + server);
 let buzzButton = document.getElementById("buzzButton");
 let finalAnswerInput = document.getElementById("finalAnswer");
 let finalAnswerButton = document.getElementById("finalAnswerButton");
@@ -203,6 +202,7 @@ function setUsername() {
 
 setUsername();
 
+let socket = new WebSocket("wss://" + server);
 socket.onopen = function(e) {
   document.getElementById("status").textContent = local_username.toLowerCase() + " is willing to risk it all";
   document.getElementById("connection_status").textContent = "Connected!";


### PR DESCRIPTION
If the websocket opens before the open event listener is assigned, the open
event is never fired.

The reason there was enough time for the web socket to connect seems to be the
prompt we do for the username. It takes time and probably interrupts the main
thread, allowing the connection task to be completed.

This seems to be an implementation difference between Firefox and Chrome. It
could be that Chrome will fire the event when it is added, even if the
connection is already made. It also might be that Chrome does not try to create
the connection while the prompt is open.
